### PR TITLE
chore: update MelodyHub live links to new deployment

### DIFF
--- a/PORTFOLIO_FULL_CONTENT.md
+++ b/PORTFOLIO_FULL_CONTENT.md
@@ -374,7 +374,7 @@
 **Badges:** Socket.IO, Team Work
 
 **Links:**
-- Live: https://udaymelodyhhub.vercel.app/
+- Live: http://melodyhubmusic.vercel.app/
 - GitHub: https://github.com/aabhiyann/MelodyHub
 
 **Case Study:** `/case-studies/melodyhub`

--- a/PORTFOLIO_OVERVIEW.md
+++ b/PORTFOLIO_OVERVIEW.md
@@ -373,7 +373,7 @@
 - **Stats:** Type: Team Project, Feature: Real-Time Sync
 - **Badges:** Socket.IO, Team Work
 - **Links:**
-  - Live: https://udaymelodyhhub.vercel.app/
+  - Live: http://melodyhubmusic.vercel.app/
   - GitHub: https://github.com/aabhiyann/MelodyHub
 - **Case Study:** `/case-studies/melodyhub`
 - **Image:** `/images/projects/melodyhub.png`
@@ -1175,7 +1175,7 @@ All metrics macro-averaged across three classes (dog, cat, bird)
 **Project Status Box:**
 
 - Status: Deployed (by teammate)
-- Live Demo: https://udaymelodyhhub.vercel.app/
+- Live Demo: http://melodyhubmusic.vercel.app/
 - Note: Project is live but maintained by teammate
 
 #### Section 2: The Challenge
@@ -1388,7 +1388,7 @@ socket.on("sync-playback", ({ songId, timestamp, isPlaying }) => {
 
 **Links:**
 
-- Live Demo: https://udaymelodyhhub.vercel.app/
+- Live Demo: http://melodyhubmusic.vercel.app/
 - GitHub: https://github.com/aabhiyann/MelodyHub
 
 ---
@@ -1574,7 +1574,7 @@ socket.on("sync-playback", ({ songId, timestamp, isPlaying }) => {
 
 #### MelodyHub
 
-- **Live Demo:** https://udaymelodyhhub.vercel.app/
+- **Live Demo:** http://melodyhubmusic.vercel.app/
 - **GitHub:** https://github.com/aabhiyann/MelodyHub
 
 #### Disease Prediction ML

--- a/content/blog-posts/melodyhub/01-linkedin-article.md
+++ b/content/blog-posts/melodyhub/01-linkedin-article.md
@@ -2,7 +2,7 @@
 
 **TL;DR:** I built a real-time social music platform where users listen together with synchronized playback and live chat. Here's what I learned about WebSocket architecture, state synchronization, and building scalable real-time systems.
 
-🌐 **Live Demo:** [udaymelodyhhub.vercel.app](https://udaymelodyhhub.vercel.app) (may be down)  
+🌐 **Live Demo:** [melodyhubmusic.vercel.app](http://melodyhubmusic.vercel.app) (may be down)  
 💻 **Source:** [github.com/aabhiyann/MelodyHub](https://github.com/aabhiyann/MelodyHub)
 
 ---

--- a/content/blog-posts/melodyhub/04-dev-to-medium.md
+++ b/content/blog-posts/melodyhub/04-dev-to-medium.md
@@ -11,7 +11,7 @@ canonical_url: https://your-portfolio.com/projects/melodyhub
 
 **TL;DR:** I built a real-time social music platform where users listen together with synchronized playback and live chat. Here's what I learned about WebSocket architecture, state synchronization, and building scalable real-time systems.
 
-🌐 **[Live Demo](https://udaymelodyhhub.vercel.app)** (may be down)  
+🌐 **[Live Demo](http://melodyhubmusic.vercel.app)** (may be down)  
 💻 **[Source Code](https://github.com/aabhiyann/MelodyHub)**
 
 ---

--- a/src/data/Articles.ts
+++ b/src/data/Articles.ts
@@ -636,7 +636,7 @@ Building TalkifyDocs taught me that production RAG applications are fundamentall
 
 **TL;DR:** I built a real-time social music platform where users listen together with synchronized playback and live chat. Here's what I learned about WebSocket architecture, state synchronization, and building scalable real-time systems.
 
-**[Live Demo](https://udaymelodyhhub.vercel.app)**  
+**[Live Demo](http://melodyhubmusic.vercel.app)**  
 **[Source Code](https://github.com/aabhiyann/MelodyHub)**
 
 ---

--- a/src/data/Projects.ts
+++ b/src/data/Projects.ts
@@ -93,7 +93,7 @@ export const projects: Project[] = [
     description:
       "Shared music rooms with synchronized playback and live chat. Socket.IO keeps listeners in sync across clients with under 50ms latency. Built with React, Node.js, and MongoDB.",
     tech: ["React", "Node.js", "Socket.IO", "MongoDB", "Clerk"],
-    live: "https://udaymelodyhhub.vercel.app/",
+    live: "http://melodyhubmusic.vercel.app/",
     github: "https://github.com/aabhiyann/MelodyHub",
     image: "/images/projects/melodyhub.png",
     categories: ["Full Stack"],

--- a/src/pages/case-studies/MelodyHub.tsx
+++ b/src/pages/case-studies/MelodyHub.tsx
@@ -20,7 +20,7 @@ const MelodyHubCaseStudy: React.FC = () => {
       ]}
       links={{
         github: "https://github.com/aabhiyann/MelodyHub",
-        live: "https://udaymelodyhhub.vercel.app",
+        live: "http://melodyhubmusic.vercel.app",
       }}
     >
       <CaseStudySection title="Overview">
@@ -45,12 +45,12 @@ const MelodyHubCaseStudy: React.FC = () => {
             <Typography variant="body" className="text-sm">
               <strong>Deployed:</strong>{" "}
               <a
-                href="https://udaymelodyhhub.vercel.app"
+                href="http://melodyhubmusic.vercel.app"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-accent-primary hover:underline"
               >
-                udaymelodyhhub.vercel.app
+                melodyhubmusic.vercel.app
               </a>{" "}
               (may be down, deployed by teammate)
             </Typography>
@@ -644,7 +644,7 @@ graph TB
             </Typography>
           </a>
           <a
-            href="https://udaymelodyhhub.vercel.app"
+            href="http://melodyhubmusic.vercel.app"
             target="_blank"
             rel="noopener noreferrer"
             className="p-6 rounded-xl bg-bg-surface/50 border border-border-primary/50 hover:border-accent-primary/50 transition-colors group"


### PR DESCRIPTION
## Summary
- update MelodyHub live/demo links to the new deployed URL
- align links across project data, case study page, blog content, and portfolio docs

## Test plan
- [x] verify no `udaymelodyhhub.vercel.app` references remain
- [x] confirm working tree is clean after commit